### PR TITLE
Add gif command

### DIFF
--- a/src/commands/gif/index.test.ts
+++ b/src/commands/gif/index.test.ts
@@ -1,0 +1,108 @@
+import { generateGifEmbed } from '.';
+import { WaifuSchema } from '../../schemas/waifu';
+
+const props: WaifuSchema = {
+  signature: 'a signature',
+  extension: 'an extension',
+  image_id: 1,
+  favorites: 100,
+  dominant_color: 'a color',
+  source: 'a source',
+  uploaded_at: 'uploaded sometime',
+  liked_at: null,
+  is_nsfw: false,
+  width: 100,
+  height: 200,
+  byte_size: 20,
+  url: 'a url',
+  preview_url: 'a preview',
+  tags: [
+    {
+      tag_id: 1,
+      name: 'a tag',
+      description: 'a description',
+      is_nsfw: false,
+    },
+  ],
+};
+
+describe('Gif Command', () => {
+  it('generates an embed correctly', () => {
+    const embed = generateGifEmbed(props);
+
+    expect(embed).not.toBeUndefined();
+  });
+  it('displays the correct fields in the embed', () => {
+    const embed = generateGifEmbed(props);
+
+    expect(embed.description).not.toBeUndefined();
+    expect(embed.color).not.toBeUndefined();
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields.length).toBe(2);
+  });
+  it('shows the correct color in the embed', () => {
+    const embed = generateGifEmbed({ ...props, dominant_color: '#800000' });
+
+    expect(embed.color).not.toBeUndefined();
+    expect(embed.color).toBe(8388608);
+  });
+  it('shows the correct tags in the embed if there are no tags', () => {
+    const embed = generateGifEmbed({ ...props, tags: [] });
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[1].name).toBe('Tags');
+    expect(embed.fields && embed.fields[1].value).toBe('');
+  });
+  it('shows the correct tags in the embed if there is only one tag', () => {
+    const tags = [
+      {
+        tag_id: 1,
+        name: 'waifu',
+        description: 'a description',
+        is_nsfw: false,
+      },
+    ];
+    const embed = generateGifEmbed({ ...props, tags });
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[1].name).toBe('Tags');
+    expect(embed.fields && embed.fields[1].value.includes(',')).toBe(false);
+    expect(embed.fields && embed.fields[1].value).toBe('waifu');
+  });
+  it('shows the correct tags in the embed if there are a couple of tags', () => {
+    const tags = [
+      {
+        tag_id: 1,
+        name: 'waifu',
+        description: 'a description',
+        is_nsfw: false,
+      },
+      {
+        tag_id: 2,
+        name: 'uniform',
+        description: 'a description',
+        is_nsfw: false,
+      },
+    ];
+    const embed = generateGifEmbed({ ...props, tags });
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[1].name).toBe('Tags');
+    expect(embed.fields && embed.fields[1].value.includes(',')).toBe(true);
+    expect(embed.fields && embed.fields[1].value).toBe('waifu, uniform');
+  });
+  it('shows the correct orientation if width is larger than height', () => {
+    const embed = generateGifEmbed({ ...props, width: 1200, height: 1000 });
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[0].name).toBe('Orientation');
+    expect(embed.fields && embed.fields[0].value).toBe('Landscape');
+  });
+  it('shows the correct orientation if height is larger than width', () => {
+    const embed = generateGifEmbed({ ...props, width: 1000, height: 1200 });
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[0].name).toBe('Orientation');
+    expect(embed.fields && embed.fields[0].value).toBe('Portrait');
+  });
+});

--- a/src/commands/gif/index.ts
+++ b/src/commands/gif/index.ts
@@ -1,0 +1,53 @@
+import { APIEmbed, hyperlink, SlashCommandBuilder } from 'discord.js';
+import { isEmpty, reduce } from 'lodash';
+import { WaifuSchema } from '../../schemas/waifu';
+import { getWaifu } from '../../services/adapters';
+import { sendErrorLog } from '../../utils/helpers';
+import { AppCommand, AppCommandOptions } from '../commands';
+
+export const generateGifEmbed = (data: WaifuSchema): APIEmbed => {
+  const color = parseInt(data.dominant_color.replace('#', '0x'));
+  const tags = reduce(
+    data.tags,
+    (accumulator, value) => {
+      return `${accumulator}${isEmpty(accumulator) ? '' : ', '}${value.name}`;
+    },
+    ''
+  );
+  const orientation: 'Portrait' | 'Landscape' = data.width > data.height ? 'Landscape' : 'Portrait';
+  const embed: APIEmbed = {
+    color,
+    description: `${hyperlink('Source', data.source)} | ${hyperlink('Preview', data.preview_url)}`,
+    image: {
+      url: data.url,
+    },
+    fields: [
+      {
+        name: 'Orientation',
+        value: orientation,
+        inline: true,
+      },
+      {
+        name: 'Tags',
+        value: tags,
+        inline: true,
+      },
+    ],
+  };
+  return embed;
+};
+
+export default {
+  commandType: 'Waifu',
+  data: new SlashCommandBuilder().setName('gif').setDescription('Shows a random waifu gif'),
+  async execute({ interaction }: AppCommandOptions) {
+    try {
+      await interaction.deferReply();
+      const data = await getWaifu({ isGif: true });
+      const embed = generateGifEmbed(data);
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      sendErrorLog({ error, interaction });
+    }
+  },
+} as AppCommand;

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -3,9 +3,13 @@ import { WaifuAPI, WaifuSchema } from '../schemas/waifu';
 
 const BASE_URL = 'https://api.waifu.im';
 
-export async function getWaifu(): Promise<WaifuSchema> {
+interface WaifuProps {
+  isGif?: boolean;
+}
+
+export async function getWaifu(props?: WaifuProps): Promise<WaifuSchema> {
   const response = (await got
-    .get(`${BASE_URL}/search?orientation=RANDOM&is_nsfw=FALSE`)
+    .get(`${BASE_URL}/search?orientation=RANDOM&is_nsfw=false&gif=${props ? props.isGif : false}`)
     .json()) as WaifuAPI;
   return response.images[0];
 }


### PR DESCRIPTION
#### Context
Initially just wanted a image command but it's not a lot of extra effort to add a gif command as well. Tho the waifu api doesn't look it supports a lot of gifs atm. Or rather, it doesn't have any SFW gifs and the rest are all pretty sus. I don't really have a need for the nsfw ones so I might take a look at other APIs. https://otakugifs.xyz/ might have potential

![gif command](https://user-images.githubusercontent.com/42207245/233459647-395e5f85-f47e-4445-a401-15fb205938d0.gif)

#### Change
- Create gif command
