### PR TITLE
Create image command

### DIFF
--- a/src/commands/gif/index.test.ts
+++ b/src/commands/gif/index.test.ts
@@ -27,6 +27,6 @@ describe('Waifu Command', () => {
     const embed = generateGifEmbed(data, reaction);
 
     expect(embed.title).not.toBeUndefined();
-    expect(embed.title).toBe('Gif Command | Test reaction');
+    expect(embed.title).toBe('Random Gif | Test reaction');
   });
 });

--- a/src/commands/gif/index.ts
+++ b/src/commands/gif/index.ts
@@ -22,7 +22,6 @@ export default {
   data: new SlashCommandBuilder().setName('gif').setDescription('Shows a random anime gif'),
   async execute({ interaction }: AppCommandOptions) {
     try {
-      await interaction.deferReply();
       const reactions = await getOtakuReactions();
       const randomReaction = reactions[Math.floor(Math.random() * reactions.length)];
       const data = await getOtakuGif(randomReaction);

--- a/src/commands/gif/index.ts
+++ b/src/commands/gif/index.ts
@@ -18,7 +18,7 @@ export const generateGifEmbed = (data: OtakuAPISchema, reaction: string): APIEmb
 };
 
 export default {
-  commandType: 'Waifu',
+  commandType: 'Anime',
   data: new SlashCommandBuilder().setName('gif').setDescription('Shows a random anime gif'),
   async execute({ interaction }: AppCommandOptions) {
     try {

--- a/src/commands/gif/index.ts
+++ b/src/commands/gif/index.ts
@@ -22,6 +22,7 @@ export default {
   data: new SlashCommandBuilder().setName('gif').setDescription('Shows a random anime gif'),
   async execute({ interaction }: AppCommandOptions) {
     try {
+      await interaction.deferReply();
       const reactions = await getOtakuReactions();
       const randomReaction = reactions[Math.floor(Math.random() * reactions.length)];
       const data = await getOtakuGif(randomReaction);

--- a/src/commands/gif/index.ts
+++ b/src/commands/gif/index.ts
@@ -8,7 +8,7 @@ import { AppCommand, AppCommandOptions } from '../commands';
 export const generateGifEmbed = (data: OtakuAPISchema, reaction: string): APIEmbed => {
   const color = parseInt('#ff0055'.replace('#', '0x'));
   const embed: APIEmbed = {
-    title: `Gif Command | ${capitalize(reaction)}`,
+    title: `Random Gif | ${capitalize(reaction)}`,
     color,
     image: {
       url: data.url,

--- a/src/commands/image/index.test.ts
+++ b/src/commands/image/index.test.ts
@@ -63,6 +63,24 @@ describe('Image Command', () => {
     expect(embed.color).not.toBeUndefined();
     expect(embed.color).toBe(8388608);
   });
+  it('shows the correct artist in the embed if there is no artist', () => {
+    const embed = generateImageEmbed(props);
+
+    expect(embed.fields && embed.fields[0].name).toBe('Artist');
+    expect(embed.fields && embed.fields[0].value).toBe('-');
+  });
+  it('shows the correct artist in the embed if there is an artist', () => {
+    const artist = {
+      id: '1',
+      name: 'Test artist',
+      url: 'a url',
+      images: 1234,
+    };
+    const embed = generateImageEmbed({ ...props, artist });
+
+    expect(embed.fields && embed.fields[0].name).toBe('Artist');
+    expect(embed.fields && embed.fields[0].value).toBe('Test artist');
+  });
   it('shows the correct categories in the embed if there are no categories', () => {
     const embed = generateImageEmbed({ ...props, categories: [] });
 

--- a/src/commands/image/index.test.ts
+++ b/src/commands/image/index.test.ts
@@ -1,0 +1,114 @@
+import { generateImageEmbed } from '.';
+import { NekosImageSchema } from '../../schemas/nekos';
+
+const props: NekosImageSchema = {
+  id: 'an id',
+  url: 'a url',
+  artist: null,
+  source: {
+    name: null,
+    url: null,
+  },
+  nsfw: false,
+  original: false,
+  categories: [],
+  characters: [],
+  createdAt: 'a date',
+  meta: {
+    eTag: 'an etag',
+    size: 1234,
+    mimetype: 'a mimetype',
+    color: 'a color',
+    expires: 'a date',
+    dimens: {
+      width: 1234,
+      height: 4321,
+      aspectRatio: 'an aspect ratio',
+      orientation: 'an orientation',
+    },
+  },
+};
+
+describe('Image Command', () => {
+  it('generates an embed correctly', () => {
+    const embed = generateImageEmbed(props);
+
+    expect(embed).not.toBeUndefined();
+  });
+  it('displays the correct fields in the embed', () => {
+    const embed = generateImageEmbed(props);
+
+    expect(embed.color).not.toBeUndefined();
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields.length).toBe(2);
+  });
+  it('does not display the description if source name is null', () => {
+    const embed = generateImageEmbed(props);
+
+    expect(embed.description).toBeUndefined();
+  });
+  it('does not display the description if source url is null', () => {
+    const embed = generateImageEmbed(props);
+
+    expect(embed.description).toBeUndefined();
+  });
+  it('displays the description if both source name and source url is defined', () => {
+    const embed = generateImageEmbed({ ...props, source: { name: 'Test name', url: 'Test url' } });
+
+    expect(embed.description).not.toBeUndefined();
+  });
+  it('shows the correct color in the embed', () => {
+    const embed = generateImageEmbed({ ...props, meta: { ...props.meta, color: '#800000' } });
+
+    expect(embed.color).not.toBeUndefined();
+    expect(embed.color).toBe(8388608);
+  });
+  it('shows the correct categories in the embed if there are no categories', () => {
+    const embed = generateImageEmbed({ ...props, categories: [] });
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[1].name).toBe('Tags');
+    expect(embed.fields && embed.fields[1].value).toBe('-');
+  });
+  it('shows the correct category in the embed if there is only one category', () => {
+    const categories = [
+      {
+        id: '1',
+        name: 'Girl',
+        description: 'a description',
+        nsfw: false,
+        createdAt: 'some date',
+      },
+    ];
+    const embed = generateImageEmbed({ ...props, categories });
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[1].name).toBe('Tags');
+    expect(embed.fields && embed.fields[1].value.includes(',')).toBe(false);
+    expect(embed.fields && embed.fields[1].value).toBe('Girl');
+  });
+  it('shows the correct categories in the embed if there are a couple of categories', () => {
+    const categories = [
+      {
+        id: '1',
+        name: 'Girl',
+        description: 'a description',
+        nsfw: false,
+        createdAt: 'some date',
+      },
+      {
+        id: '2',
+        name: 'Nekomimi',
+        description: 'a description',
+        nsfw: false,
+        createdAt: 'some date',
+      },
+    ];
+    const embed = generateImageEmbed({ ...props, categories });
+
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields && embed.fields[1].name).toBe('Tags');
+    expect(embed.fields && embed.fields[1].value.includes(',')).toBe(true);
+    expect(embed.fields && embed.fields[1].value).toBe('Girl, Nekomimi');
+  });
+});

--- a/src/commands/image/index.ts
+++ b/src/commands/image/index.ts
@@ -15,6 +15,7 @@ export const generateImageEmbed = (data: NekosImageSchema): APIEmbed => {
     ''
   );
   const embed: APIEmbed = {
+    title: 'Random Image',
     description:
       data.source.url && data.source.name
         ? `${hyperlink('Source URL', data.source.url)} | ${hyperlink(

--- a/src/commands/image/index.ts
+++ b/src/commands/image/index.ts
@@ -48,6 +48,7 @@ export default {
   data: new SlashCommandBuilder().setName('image').setDescription('Shows a random anime image'),
   async execute({ interaction }: AppCommandOptions) {
     try {
+      await interaction.deferReply();
       const data = await getNekosImage();
       const embed = generateImageEmbed(data);
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/image/index.ts
+++ b/src/commands/image/index.ts
@@ -1,0 +1,29 @@
+import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import { getNekosImage } from '../../services/adapters';
+import { sendErrorLog } from '../../utils/helpers';
+import { AppCommand, AppCommandOptions } from '../commands';
+
+export const generateImageEmbed = (data: any): APIEmbed => {
+  const color = parseInt('#ff0055'.replace('#', '0x'));
+  const embed: APIEmbed = {
+    color,
+    image: {
+      url: data.url,
+    },
+  };
+  return embed;
+};
+
+export default {
+  data: new SlashCommandBuilder().setName('image').setDescription('Shows a random anime image'),
+  async execute({ interaction }: AppCommandOptions) {
+    try {
+      await interaction.deferReply();
+      const data = await getNekosImage();
+      const embed = generateImageEmbed(data);
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      sendErrorLog({ error, interaction });
+    }
+  },
+} as AppCommand;

--- a/src/commands/image/index.ts
+++ b/src/commands/image/index.ts
@@ -1,20 +1,49 @@
-import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import { APIEmbed, hyperlink, SlashCommandBuilder } from 'discord.js';
+import { isEmpty, reduce } from 'lodash';
+import { NekosImageSchema } from '../../schemas/nekos';
 import { getNekosImage } from '../../services/adapters';
 import { sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
-export const generateImageEmbed = (data: any): APIEmbed => {
-  const color = parseInt('#ff0055'.replace('#', '0x'));
+export const generateImageEmbed = (data: NekosImageSchema): APIEmbed => {
+  const color = parseInt(data.meta.color.replace('#', '0x'));
+  const tags = reduce(
+    data.categories,
+    (accumulator, value) => {
+      return `${accumulator}${isEmpty(accumulator) ? '' : ', '}${value.name}`;
+    },
+    ''
+  );
   const embed: APIEmbed = {
+    description:
+      data.source.url && data.source.name
+        ? `${hyperlink('Source URL', data.source.url)} | ${hyperlink(
+            'Source Name',
+            data.source.name
+          )}`
+        : undefined,
     color,
     image: {
       url: data.url,
     },
+    fields: [
+      {
+        name: 'Artist',
+        value: data.artist ? data.artist.name : '-',
+        inline: true,
+      },
+      {
+        name: 'Tags',
+        value: isEmpty(tags) ? '-' : tags,
+        inline: true,
+      },
+    ],
   };
   return embed;
 };
 
 export default {
+  commandType: 'Anime',
   data: new SlashCommandBuilder().setName('image').setDescription('Shows a random anime image'),
   async execute({ interaction }: AppCommandOptions) {
     try {

--- a/src/commands/image/index.ts
+++ b/src/commands/image/index.ts
@@ -48,7 +48,6 @@ export default {
   data: new SlashCommandBuilder().setName('image').setDescription('Shows a random anime image'),
   async execute({ interaction }: AppCommandOptions) {
     try {
-      await interaction.deferReply();
       const data = await getNekosImage();
       const embed = generateImageEmbed(data);
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/waifu/index.test.ts
+++ b/src/commands/waifu/index.test.ts
@@ -91,18 +91,4 @@ describe('Waifu Command', () => {
     expect(embed.fields && embed.fields[1].value.includes(',')).toBe(true);
     expect(embed.fields && embed.fields[1].value).toBe('waifu, uniform');
   });
-  it('shows the correct orientation if width is larger than height', () => {
-    const embed = generateWaifuEmbed({ ...props, width: 1200, height: 1000 });
-
-    expect(embed.fields).not.toBeUndefined();
-    expect(embed.fields && embed.fields[0].name).toBe('Orientation');
-    expect(embed.fields && embed.fields[0].value).toBe('Landscape');
-  });
-  it('shows the correct orientation if height is larger than width', () => {
-    const embed = generateWaifuEmbed({ ...props, width: 1000, height: 1200 });
-
-    expect(embed.fields).not.toBeUndefined();
-    expect(embed.fields && embed.fields[0].name).toBe('Orientation');
-    expect(embed.fields && embed.fields[0].value).toBe('Portrait');
-  });
 });

--- a/src/commands/waifu/index.test.ts
+++ b/src/commands/waifu/index.test.ts
@@ -38,7 +38,7 @@ describe('Waifu Command', () => {
     expect(embed.description).not.toBeUndefined();
     expect(embed.color).not.toBeUndefined();
     expect(embed.fields).not.toBeUndefined();
-    expect(embed.fields && embed.fields.length).toBe(2);
+    expect(embed.fields && embed.fields.length).toBe(1);
   });
   it('shows the correct color in the embed', () => {
     const embed = generateWaifuEmbed({ ...props, dominant_color: '#800000' });
@@ -50,10 +50,10 @@ describe('Waifu Command', () => {
     const embed = generateWaifuEmbed({ ...props, tags: [] });
 
     expect(embed.fields).not.toBeUndefined();
-    expect(embed.fields && embed.fields[1].name).toBe('Tags');
-    expect(embed.fields && embed.fields[1].value).toBe('');
+    expect(embed.fields && embed.fields[0].name).toBe('Tags');
+    expect(embed.fields && embed.fields[0].value).toBe('-');
   });
-  it('shows the correct tags in the embed if there is only one tag', () => {
+  it('shows the correct tag in the embed if there is only one tag', () => {
     const tags = [
       {
         tag_id: 1,
@@ -65,9 +65,9 @@ describe('Waifu Command', () => {
     const embed = generateWaifuEmbed({ ...props, tags });
 
     expect(embed.fields).not.toBeUndefined();
-    expect(embed.fields && embed.fields[1].name).toBe('Tags');
-    expect(embed.fields && embed.fields[1].value.includes(',')).toBe(false);
-    expect(embed.fields && embed.fields[1].value).toBe('waifu');
+    expect(embed.fields && embed.fields[0].name).toBe('Tags');
+    expect(embed.fields && embed.fields[0].value.includes(',')).toBe(false);
+    expect(embed.fields && embed.fields[0].value).toBe('waifu');
   });
   it('shows the correct tags in the embed if there are a couple of tags', () => {
     const tags = [
@@ -87,8 +87,8 @@ describe('Waifu Command', () => {
     const embed = generateWaifuEmbed({ ...props, tags });
 
     expect(embed.fields).not.toBeUndefined();
-    expect(embed.fields && embed.fields[1].name).toBe('Tags');
-    expect(embed.fields && embed.fields[1].value.includes(',')).toBe(true);
-    expect(embed.fields && embed.fields[1].value).toBe('waifu, uniform');
+    expect(embed.fields && embed.fields[0].name).toBe('Tags');
+    expect(embed.fields && embed.fields[0].value.includes(',')).toBe(true);
+    expect(embed.fields && embed.fields[0].value).toBe('waifu, uniform');
   });
 });

--- a/src/commands/waifu/index.ts
+++ b/src/commands/waifu/index.ts
@@ -1,7 +1,7 @@
 import { APIEmbed, hyperlink, SlashCommandBuilder } from 'discord.js';
 import { isEmpty, reduce } from 'lodash';
 import { WaifuSchema } from '../../schemas/waifu';
-import { getNekosImage, getWaifu } from '../../services/adapters';
+import { getWaifu } from '../../services/adapters';
 import { sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
@@ -43,7 +43,6 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
-      await getNekosImage();
       const data = await getWaifu();
       const embed = generateWaifuEmbed(data);
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/waifu/index.ts
+++ b/src/commands/waifu/index.ts
@@ -37,7 +37,6 @@ export default {
   data: new SlashCommandBuilder().setName('waifu').setDescription('Shows a random waifu image'),
   async execute({ interaction }: AppCommandOptions) {
     try {
-      await interaction.deferReply();
       const data = await getWaifu();
       const embed = generateWaifuEmbed(data);
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/waifu/index.ts
+++ b/src/commands/waifu/index.ts
@@ -37,6 +37,7 @@ export default {
   data: new SlashCommandBuilder().setName('waifu').setDescription('Shows a random waifu image'),
   async execute({ interaction }: AppCommandOptions) {
     try {
+      await interaction.deferReply();
       const data = await getWaifu();
       const embed = generateWaifuEmbed(data);
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/waifu/index.ts
+++ b/src/commands/waifu/index.ts
@@ -24,7 +24,7 @@ export const generateWaifuEmbed = (data: WaifuSchema): APIEmbed => {
     fields: [
       {
         name: 'Tags',
-        value: tags,
+        value: isEmpty(tags) ? '-' : tags,
         inline: true,
       },
     ],

--- a/src/commands/waifu/index.ts
+++ b/src/commands/waifu/index.ts
@@ -14,19 +14,14 @@ export const generateWaifuEmbed = (data: WaifuSchema): APIEmbed => {
     },
     ''
   );
-  const orientation: 'Portrait' | 'Landscape' = data.width > data.height ? 'Landscape' : 'Portrait';
   const embed: APIEmbed = {
+    title: 'Random Waifu',
     color,
     description: `${hyperlink('Source', data.source)} | ${hyperlink('Preview', data.preview_url)}`,
     image: {
       url: data.url,
     },
     fields: [
-      {
-        name: 'Orientation',
-        value: orientation,
-        inline: true,
-      },
       {
         name: 'Tags',
         value: tags,

--- a/src/commands/waifu/index.ts
+++ b/src/commands/waifu/index.ts
@@ -1,7 +1,7 @@
 import { APIEmbed, hyperlink, SlashCommandBuilder } from 'discord.js';
 import { isEmpty, reduce } from 'lodash';
 import { WaifuSchema } from '../../schemas/waifu';
-import { getWaifu } from '../../services/adapters';
+import { getNekosCategories, getWaifu } from '../../services/adapters';
 import { sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
@@ -43,6 +43,7 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
+      await getNekosCategories();
       const data = await getWaifu();
       const embed = generateWaifuEmbed(data);
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/waifu/index.ts
+++ b/src/commands/waifu/index.ts
@@ -1,7 +1,7 @@
 import { APIEmbed, hyperlink, SlashCommandBuilder } from 'discord.js';
 import { isEmpty, reduce } from 'lodash';
 import { WaifuSchema } from '../../schemas/waifu';
-import { getNekosCategories, getWaifu } from '../../services/adapters';
+import { getNekosImage, getWaifu } from '../../services/adapters';
 import { sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
@@ -43,7 +43,7 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
-      await getNekosCategories();
+      await getNekosImage();
       const data = await getWaifu();
       const embed = generateWaifuEmbed(data);
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/waifu/index.ts
+++ b/src/commands/waifu/index.ts
@@ -38,7 +38,7 @@ export const generateWaifuEmbed = (data: WaifuSchema): APIEmbed => {
 };
 
 export default {
-  commandType: 'Waifu',
+  commandType: 'Anime',
   data: new SlashCommandBuilder().setName('waifu').setDescription('Shows a random waifu image'),
   async execute({ interaction }: AppCommandOptions) {
     try {

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -9,7 +9,6 @@ export default function ({ app, appCommands, mixpanel }: EventModule) {
       if (!interaction.inGuild() || !appCommands) return;
 
       if (interaction.isCommand()) {
-        await interaction.deferReply();
         const { commandName } = interaction;
         const command = appCommands.find((command) => command.data.name === commandName);
         command && (await command.execute({ interaction, app, appCommands }));

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -9,6 +9,7 @@ export default function ({ app, appCommands, mixpanel }: EventModule) {
       if (!interaction.inGuild() || !appCommands) return;
 
       if (interaction.isCommand()) {
+        await interaction.deferReply();
         const { commandName } = interaction;
         const command = appCommands.find((command) => command.data.name === commandName);
         command && (await command.execute({ interaction, app, appCommands }));

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -40,7 +40,7 @@ export default function ({ app, appCommands }: EventModule) {
       }
       await sendBootNotification(app);
     } catch (error) {
-      console.log(error);
+      sendErrorLog({ error });
     }
   });
 }

--- a/src/schemas/nekos.ts
+++ b/src/schemas/nekos.ts
@@ -1,0 +1,57 @@
+//Schemas for the nekosapi API
+export interface NekosImageAPISchema {
+  data: NekosImageSchema[];
+  success: boolean;
+}
+export interface NekosImageSchema {
+  id: string;
+  url: string;
+  artist: NekosArtistSchema | null;
+  source: {
+    name: string;
+    url: string;
+  };
+  nsfw: boolean;
+  categories: NekosCategorySchema[];
+  characters: NekosCharacterSchema[];
+  createdAt: string;
+  meta: NekosImageMeta;
+}
+export interface NekosArtistSchema {
+  id: string;
+  name: string;
+  url: string;
+  images: number;
+}
+export interface NekosCategorySchema {
+  id: string;
+  name: string;
+  description: string;
+  nsfw: boolean;
+  createdAt: string;
+}
+export interface NekosCharacterSchema {
+  id: string;
+  name: string;
+  description: string;
+  source: string;
+  gender: string;
+  ages: number[];
+  birth_date: string;
+  nationality: string;
+  occupations: string[];
+  createdAt: string;
+}
+export interface NekosImageMeta {
+  eTag: string;
+  size: number;
+  mimetype: string;
+  color: string;
+  expires: string;
+  dimens: {
+    width: number;
+    height: number;
+    aspectRatio: string;
+    orientation: string;
+  };
+}

--- a/src/schemas/nekos.ts
+++ b/src/schemas/nekos.ts
@@ -12,6 +12,7 @@ export interface NekosImageSchema {
     url: string;
   };
   nsfw: boolean;
+  original: boolean | null;
   categories: NekosCategorySchema[];
   characters: NekosCharacterSchema[];
   createdAt: string;

--- a/src/schemas/nekos.ts
+++ b/src/schemas/nekos.ts
@@ -8,8 +8,8 @@ export interface NekosImageSchema {
   url: string;
   artist: NekosArtistSchema | null;
   source: {
-    name: string;
-    url: string;
+    name: string | null;
+    url: string | null;
   };
   nsfw: boolean;
   original: boolean | null;

--- a/src/schemas/waifu.ts
+++ b/src/schemas/waifu.ts
@@ -1,5 +1,5 @@
 //Schemas for the waifu.im API; currently only for the GET /search endpoint
-export interface WaifuAPI {
+export interface WaifuAPISchema {
   images: WaifuSchema[];
 }
 export interface WaifuSchema {

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -35,13 +35,12 @@ export async function getNekosCategories() {
     const response = await got
       .get(`https://v1.nekosapi.com/api/category?limit=25&offset=25`)
       .json();
-    console.log(response);
+    return response;
   } catch (error) {
     sendErrorLog({ error });
   }
 }
 export async function getNekosImage() {
-  const response = await got.get(`https://v1.nekosapi.com/api/image/random`).json();
-
-  console.log(response);
+  const response: any = await got.get(`https://v1.nekosapi.com/api/image/random?limit=1`).json();
+  return response.data[0];
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -3,15 +3,9 @@ import { NekosImageAPISchema, NekosImageSchema } from '../schemas/nekos';
 import { OtakuAPISchema, OtakuReactionsAPISchema } from '../schemas/otaku';
 import { WaifuAPISchema, WaifuSchema } from '../schemas/waifu';
 
-const BASE_URL = 'https://api.waifu.im';
-
-interface WaifuProps {
-  isGif?: boolean;
-}
-
-export async function getWaifu(props?: WaifuProps): Promise<WaifuSchema> {
+export async function getWaifu(isGif?: boolean): Promise<WaifuSchema> {
   const response = (await got
-    .get(`${BASE_URL}/search?orientation=RANDOM&is_nsfw=false&gif=${props ? props.isGif : false}`)
+    .get(`https://api.waifu.im/search?orientation=RANDOM&is_nsfw=false&gif=${isGif && isGif}`)
     .json()) as WaifuAPISchema;
   return response.images[0];
 }
@@ -29,7 +23,7 @@ export async function getOtakuGif(reaction: string): Promise<OtakuAPISchema> {
     .json()) as OtakuAPISchema;
   return response;
 }
-
+//TODO: Explore what we can do with categories
 export async function getNekosCategories() {
   const response = await got.get(`https://v1.nekosapi.com/api/category?limit=25&offset=25`).json();
   return response;

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -1,6 +1,7 @@
 import got from 'got';
 import { OtakuAPISchema, OtakuReactionsAPISchema } from '../schemas/otaku';
 import { WaifuAPI, WaifuSchema } from '../schemas/waifu';
+import { sendErrorLog } from '../utils/helpers';
 
 const BASE_URL = 'https://api.waifu.im';
 
@@ -27,4 +28,15 @@ export async function getOtakuGif(reaction: string): Promise<OtakuAPISchema> {
     .get(`https://api.otakugifs.xyz/gif?reaction=${reaction}&format=gif`)
     .json()) as OtakuAPISchema;
   return response;
+}
+
+export async function getNekosCategories() {
+  try {
+    const response = await got
+      .get(`https://v1.nekosapi.com/api/category?limit=25&offset=25`)
+      .json();
+    console.log(response);
+  } catch (error) {
+    sendErrorLog({ error });
+  }
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -3,9 +3,9 @@ import { NekosImageAPISchema, NekosImageSchema } from '../schemas/nekos';
 import { OtakuAPISchema, OtakuReactionsAPISchema } from '../schemas/otaku';
 import { WaifuAPISchema, WaifuSchema } from '../schemas/waifu';
 
-export async function getWaifu(isGif?: boolean): Promise<WaifuSchema> {
+export async function getWaifu(): Promise<WaifuSchema> {
   const response = (await got
-    .get(`https://api.waifu.im/search?orientation=RANDOM&is_nsfw=false&gif=${isGif && isGif}`)
+    .get(`https://api.waifu.im/search?orientation=RANDOM&is_nsfw=false`)
     .json()) as WaifuAPISchema;
   return response.images[0];
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -38,6 +38,5 @@ export async function getNekosImage(): Promise<NekosImageSchema> {
   const response = (await got
     .get(`https://v1.nekosapi.com/api/image/random?limit=1`)
     .json()) as NekosImageAPISchema;
-  console.log(response);
   return response.data[0];
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -1,7 +1,7 @@
 import got from 'got';
+import { NekosImageAPISchema, NekosImageSchema } from '../schemas/nekos';
 import { OtakuAPISchema, OtakuReactionsAPISchema } from '../schemas/otaku';
-import { WaifuAPI, WaifuSchema } from '../schemas/waifu';
-import { sendErrorLog } from '../utils/helpers';
+import { WaifuAPISchema, WaifuSchema } from '../schemas/waifu';
 
 const BASE_URL = 'https://api.waifu.im';
 
@@ -12,7 +12,7 @@ interface WaifuProps {
 export async function getWaifu(props?: WaifuProps): Promise<WaifuSchema> {
   const response = (await got
     .get(`${BASE_URL}/search?orientation=RANDOM&is_nsfw=false&gif=${props ? props.isGif : false}`)
-    .json()) as WaifuAPI;
+    .json()) as WaifuAPISchema;
   return response.images[0];
 }
 
@@ -31,16 +31,13 @@ export async function getOtakuGif(reaction: string): Promise<OtakuAPISchema> {
 }
 
 export async function getNekosCategories() {
-  try {
-    const response = await got
-      .get(`https://v1.nekosapi.com/api/category?limit=25&offset=25`)
-      .json();
-    return response;
-  } catch (error) {
-    sendErrorLog({ error });
-  }
+  const response = await got.get(`https://v1.nekosapi.com/api/category?limit=25&offset=25`).json();
+  return response;
 }
-export async function getNekosImage() {
-  const response: any = await got.get(`https://v1.nekosapi.com/api/image/random?limit=1`).json();
+export async function getNekosImage(): Promise<NekosImageSchema> {
+  const response = (await got
+    .get(`https://v1.nekosapi.com/api/image/random?limit=1`)
+    .json()) as NekosImageAPISchema;
+  console.log(response);
   return response.data[0];
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -40,3 +40,8 @@ export async function getNekosCategories() {
     sendErrorLog({ error });
   }
 }
+export async function getNekosImage() {
+  const response = await got.get(`https://v1.nekosapi.com/api/image/random`).json();
+
+  console.log(response);
+}


### PR DESCRIPTION
#### Context
Debatable if this command was necessary, especially since the `waifu` command already gives amazing waifu images. I'll admit that after implementing the gif command that I got curious if its image counterpart was good as well. Well I tried it and   I liked it enough to make this pr

My only gripes with it tho is that it's considerably slower than the waifu api and most of the relationship data (categories, artist, source, etc) usually come back as empty. Overall tho it's pretty good and maybe I'll figure out what I can do with its other endpoints next time. Sticking with just all random for now tho

Documentation: https://v1.nekosapi.com/
Github: https://github.com/Nekidev/Nekos-API

![image command](https://user-images.githubusercontent.com/42207245/233790011-57fda526-c6fc-46c1-a0b9-ab789b30ba61.gif)

#### Change
- Create adapter for nekos endpoints
- Add schemas for nekos endpoints
- Create image command
- Cleanup anime commands
