### PR TITLE
Add sfw filter in nekos query request

### DIFF
--- a/src/schemas/nekosV2/image.ts
+++ b/src/schemas/nekosV2/image.ts
@@ -8,7 +8,7 @@ export interface NekosImageV2APISchema {
   attributes: NekosImageV2AttributeSchema;
   relationships: NekosImageV2RelationshipSchema;
   links: {
-    self: 'https://api.nekosapi.com/v2/images/fb07fa64-cc3e-4ee2-a8df-fb905d457996';
+    self: string;
   };
 }
 export interface NekosImageV2AttributeSchema {

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -67,13 +67,16 @@ export async function getNekosImageV2() {
     },
     ''
   );
-  //TODO: Figure out how to filter out nsfw stuff
+  //Age Rating filters = 'sfw', 'questionable', 'borderline', 'explicit'
   const response = (await got
-    .get(`https://api.nekosapi.com/v2/images/random?include=${includedQueryString}`, {
-      headers: {
-        accept: 'application/vnd.api+json',
-      },
-    })
+    .get(
+      `https://api.nekosapi.com/v2/images/random?include=${includedQueryString}&filter[ageRating]=sfw`,
+      {
+        headers: {
+          accept: 'application/vnd.api+json',
+        },
+      }
+    )
     .json()) as NekosImageV2APIObject;
 
   return nekosImageDecorator(response);


### PR DESCRIPTION
#### Context
When switching over to the v2 endpoint of nekos, I noticed a substantial difference in getting nsfw images opposed to sfw ones. I'm assuming a bunch of the images in v2 are sus ones but I've also noticed that some of these images are tagged wrongly. E.g `questionable` and `borderline` age ratings are blown out NSFW sometimes

I don't really care in having these so I've filtered out the request to just get sfw images. I have a worry that this affects the quality and uniqueness of the images returned but it's a sacrifice we have to take for now

![image](https://user-images.githubusercontent.com/42207245/233941571-1160bce5-7dc0-4e32-97ef-b3e88de79e71.png)

#### Change
- Add sfw filter to image request
