### PR TITLE
Create schedule worklfow

### DIFF
--- a/.github/workflows/daily-schedule.yml
+++ b/.github/workflows/daily-schedule.yml
@@ -1,0 +1,32 @@
+name: daily/schedule
+
+on:
+  schedule:
+    - cron: '0 14 * * *' # 10pm in Singapore time (minus 8)
+
+jobs:
+  logs-in-discord:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout schedule branch
+        uses: actions/checkout@v3
+        with:
+          ref: schedule/daily-workflow
+
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Create config files
+        run: |
+          mkdir src/config
+          echo "${{ secrets.ENVIRONMENT_DEV }}" > src/config/environment.ts
+          echo "${{ secrets.DATABASE_DEV }}" > src/config/database.ts
+
+      - name: Initialise discord bot
+        run: yarn trigger:schedule


### PR DESCRIPTION
#### Context
Initially thought I can just create a cron workflow in a `schedule` branch but apparently they only get triggered if they're in the base branch; which in my case is `develop`. We can however checkout to a specific branch in the workflow so I don't have to add the unnecessary code in the main branch

Testing this at 10pm for now. Will open another pr to add the correct time if it's working as intended

Basically what will be sent:
![image](https://user-images.githubusercontent.com/42207245/235306657-10e33f9c-d55a-495d-8245-2cb09ba5e39e.png)

#### Change
- Create schedule workflow
