### PR TITLE
Set daily schedule to 1:30pm

### DIFF
--- a/.github/workflows/daily-schedule.yml
+++ b/.github/workflows/daily-schedule.yml
@@ -2,7 +2,7 @@ name: daily/schedule
 
 on:
   schedule:
-    - cron: '0 14 * * *' # 10pm in Singapore time (minus 8)
+    - cron: '30 5 * * *' # 10pm in Singapore time (minus 8)
 
 jobs:
   logs-in-discord:


### PR DESCRIPTION
#### Context
Setting the daily schedule to 1:30pm. Wanted to have this at 2pm but it takes a while for it to get triggered. I'm assuming since github has millions of triggers to go through first

#### Change
- Set schedule to 1:30pm
