### PR TITLE
Add img src for gif

### DIFF
--- a/src/commands/gif/index.test.ts
+++ b/src/commands/gif/index.test.ts
@@ -19,6 +19,7 @@ describe('Waifu Command', () => {
     const embed = generateGifEmbed(data, reaction);
 
     expect(embed.title).not.toBeUndefined();
+    expect(embed.description).not.toBeUndefined();
     expect(embed.color).not.toBeUndefined();
     expect(embed.image).not.toBeUndefined();
   });

--- a/src/commands/gif/index.ts
+++ b/src/commands/gif/index.ts
@@ -1,4 +1,4 @@
-import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import { APIEmbed, inlineCode, SlashCommandBuilder } from 'discord.js';
 import { capitalize } from 'lodash';
 import { OtakuAPISchema } from '../../schemas/otaku';
 import { getOtakuGif, getOtakuReactions } from '../../services/adapters';
@@ -8,6 +8,7 @@ import { AppCommand, AppCommandOptions } from '../commands';
 export const generateGifEmbed = (data: OtakuAPISchema, reaction: string): APIEmbed => {
   const color = parseInt('#ff0055'.replace('#', '0x'));
   const embed: APIEmbed = {
+    description: `HTML Tag:\n${inlineCode(`<img src="${data.url}" />`)}`,
     title: `Random Gif | ${capitalize(reaction)}`,
     color,
     image: {


### PR DESCRIPTION
#### Context
I've been using the gifs quite a lot for my releases but a minor inconvenience was having to type out the img tag, get the link of the gif and then adding that as its src. This makes it so that an html tag is already created so I can just copy it and paste to my release notes

![image](https://github.com/vexuas/nino/assets/42207245/ca8fdd3e-6ec3-4cb4-9b65-8f0aa15a429b)

Case and point:
<img src="https://cdn.otakugifs.xyz/gifs/sneeze/27a189722df642de.gif" />

#### Change
- Add html tag to gif command
- Add tests
