### PR TITLE
Remove nekosapi v2 from image commands

### DIFF
--- a/src/commands/image/index.ts
+++ b/src/commands/image/index.ts
@@ -106,6 +106,8 @@ export default {
   data: new SlashCommandBuilder().setName('image').setDescription('Shows a random anime image'),
   async execute({ interaction }: AppCommandOptions) {
     try {
+      // TODO: v2 seems to have been deprecated in favour of v3; eventually migrate to then
+      // In the meantime, back to using v1 so it doesn't block our workflows
       await interaction.deferReply();
       const data = await getNekosImage();
       const embed = generateImageEmbed(data);

--- a/src/commands/image/index.ts
+++ b/src/commands/image/index.ts
@@ -2,7 +2,7 @@ import { APIEmbed, hyperlink, SlashCommandBuilder } from 'discord.js';
 import { isEmpty, reduce } from 'lodash';
 import { NekosImageSchema } from '../../schemas/nekos';
 import { NekosImageV2Schema } from '../../schemas/nekosV2/image';
-import { getNekosImage, getNekosImageV2 } from '../../services/adapters';
+import { getNekosImage } from '../../services/adapters';
 import { sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
@@ -104,20 +104,12 @@ export const generateImageEmbedV2 = (data: NekosImageV2Schema): APIEmbed => {
 export default {
   commandType: 'Anime',
   data: new SlashCommandBuilder().setName('image').setDescription('Shows a random anime image'),
-  async execute({ interaction, flagsmith }: AppCommandOptions) {
+  async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
-      const flags = flagsmith && (await flagsmith.getEnvironmentFlags());
-      const isUseV2Enabled = flags && flags.isFeatureEnabled('use_nekos_api_v2');
-      if (isUseV2Enabled) {
-        const data = await getNekosImageV2();
-        const embed = generateImageEmbedV2(data);
-        await interaction.editReply({ embeds: [embed] });
-      } else {
-        const data = await getNekosImage();
-        const embed = generateImageEmbed(data);
-        await interaction.editReply({ embeds: [embed] });
-      }
+      const data = await getNekosImage();
+      const embed = generateImageEmbed(data);
+      await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction });
     }


### PR DESCRIPTION
#### Context
Recently I've noticed that my daily anime pics scheduler hasn't been pinging me and it seemed to be that way for almost a month now. Looking into it, apparently I missed the memo while I was in my japan trip and v2 has been taken down due to tech debt and has been replaced in favour of v3. 

I haven't taken a look at v3 yet but I imagine there would be some migration work and setup. I have my hands full on nessie atm so I'mma just remove the v2 requests from the image command for now and opt back to using the still active v1. I'll figure out when to tackle v3 down the road.

<img width="577" alt="image" src="https://github.com/vexuas/nino/assets/42207245/aeaf82e6-3b0f-4afc-bcbc-2c03b16dc162">

<img width="354" alt="image" src="https://github.com/vexuas/nino/assets/42207245/81d8ab07-f0b5-4eda-a5e7-87ec800f3aea">

#### Change
- Remove v2 request in image command

